### PR TITLE
added simple UMD export

### DIFF
--- a/FlashDetect.js
+++ b/FlashDetect.js
@@ -198,3 +198,13 @@ var FlashDetect = new function(){
     }();
 };
 FlashDetect.JS_RELEASE = "1.0.4";
+
+if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(function () {
+       return FlashDetect;
+    });
+} else if (typeof module === 'object' && typeof module.exports === 'object') {
+    // CommonJS
+    module.exports = FlashDetect;
+}


### PR DESCRIPTION
I'm using the CommonJS section with webpack, so it should also work fine for browserify. I added the AMD bit too, for people using RequireJS and other AMD loaders. 

The global is still there as it was.

Relates to #1
